### PR TITLE
Enable build with newest pboProject

### DIFF
--- a/addons/editor/CfgCursors.hpp
+++ b/addons/editor/CfgCursors.hpp
@@ -1,3 +1,3 @@
 class GVARMAIN(cursors) {
-    DEFINE_CURSOR(select, QPATHTOF(data\Cursors\select.paa));
+    DEFINE_CURSOR(select, QPATHTOF(data\Cursors\select.paa))
 };

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -16,12 +16,14 @@
 #define SETVAR_SYS(var1,var2) setVariable [ARR_2(QUOTE(var1),var2)]
 #define SETPVAR_SYS(var1,var2) setVariable [ARR_3(QUOTE(var1),var2,true)]
 
+#undef GETVAR
 #define GETVAR(var1,var2,var3) var1 GETVAR_SYS(var2,var3)
 #define GETMVAR(var1,var2) missionNamespace GETVAR_SYS(var1,var2)
 #define GETUVAR(var1,var2) uiNamespace GETVAR_SYS(var1,var2)
 #define GETPRVAR(var1,var2) profileNamespace GETVAR_SYS(var1,var2)
 #define GETPAVAR(var1,var2) parsingNamespace GETVAR_SYS(var1,var2)
 
+#undef SETVAR
 #define SETVAR(var1,var2,var3) var1 SETVAR_SYS(var2,var3)
 #define SETPVAR(var1,var2,var3) var1 SETPVAR_SYS(var2,var3)
 #define SETMVAR(var1,var2) missionNamespace SETVAR_SYS(var1,var2)
@@ -60,6 +62,7 @@
 #ifdef DISABLE_COMPILE_CACHE
     #define PREP(fncName) DFUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(functions\DOUBLES(fnc,fncName).sqf)
 #else
+    #undef PREP
     #define PREP(fncName) [QPATHTOF(functions\DOUBLES(fnc,fncName).sqf), QFUNC(fncName)] call CBA_fnc_compileFunction
 #endif
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix pboProject's strict requirement for #undef usage, preventing a build with the newest pboProject version
- Remove a double semicolon preventing a build with the newest pboProject version
